### PR TITLE
enable build --base and TB_BUILD_OPTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,14 +49,39 @@ Box names are picked up by their dir names, so "kdev" and "py3" should be used a
 
 ### build
 
-Builds a box by its name (see the Configuration section).
+Builds a container image by the box name and an optional base (if more than one is provided).
 
-The resulting image will be tagged as `localhost/$BOX_NAME-box:latest`.
+#### Arguments
 
-Examples:
+| Name     | Type             | Description                                                       |
+|----------|------------------|-------------------------------------------------------------------|
+| box_name | Positional       | The box name to build (required)                                  |
+| base     | Optional<String> | Builds `Containerfile.$base` into `localhost/$box_name-box:$base` |
+
+#### Environment Variables
+
+| Name          | Type             | Description                          |
+|---------------|------------------|--------------------------------------|
+| TB_BUILD_OPTS | String | Optional build args to use with `podman build` |
+
+#### Examples
+
+Builds `$TB_BASE_DIR/$box_name/Containerfile` into `localhost/py3-box:latest`:
 
 ```
 $ tb build py3
+```
+
+Builds `$TB_BASE_DIR/$box_name/Containerfile.ubuntu` into `localhost/py3-box:ubuntu`:
+
+```
+$ tb build --base=ubuntu py3
+```
+
+Adding `--no-cache` to the build command:
+
+```
+$ TB_BUILD_OPTS='--no-cache' tb build py3
 ```
 
 ### rmi

--- a/src/tb-build
+++ b/src/tb-build
@@ -1,19 +1,34 @@
 #!/bin/bash
 set -e
 
+BOX_NAME=""
+CFILE="Containerfile"
+
+for arg in "$@"; do
+    case $arg in
+        --base=*)
+        CFILE="Containerfile.${arg#*=}"
+        shift
+        ;;
+    *)            
+        BOX_NAME="${1}"
+        shift
+  esac
+done
+
 if [ -z "${TB_BASE_DIR}" ]; then
     TB_BASE_DIR="${HOME}/.config/tb"
 fi
 
-BOX_NAME="${1}"
 BOX_DIR="${TB_BASE_DIR}/boxes/${BOX_NAME}"
 
-if [ ! -f "${BOX_DIR}/Containerfile" ]; then
-    echo "Cannot find box: ${BOX_DIR}"
+if [ ! -f "${BOX_DIR}/${CFILE}" ]; then
+    echo "Cannot find: ${BOX_DIR}/${CFILE}"
     exit 1
 fi
 
 podman build \
-    -f "${BOX_DIR}/Containerfile" \
+    ${TB_BUILD_OPTS} \
+    -f "${BOX_DIR}/${CFILE}" \
     -t localhost/${BOX_NAME}-box:latest \
     ${BOX_DIR}


### PR DESCRIPTION
## Changes

* allows the cli to build `Containerfile.$base` if `--base=something` is used
* `TB_BUILD_OPTS` (env var) can be used to add extra build arguments to `podman build`